### PR TITLE
hypermap: update first block for new deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "hyperware_process_lib"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperware_process_lib"
 authors = ["Sybil Technologies AG"]
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 description = "A library for writing Hyperware processes in Rust."
 homepage = "https://hyperware.ai"

--- a/src/hypermap.rs
+++ b/src/hypermap.rs
@@ -16,7 +16,7 @@ pub const HYPERMAP_ADDRESS: &'static str = "0x000000000044C6B8Cb4d8f0F889a3E4766
 /// base chain id
 pub const HYPERMAP_CHAIN_ID: u64 = 8453;
 /// first block (minus one) of hypermap deployment on base
-pub const HYPERMAP_FIRST_BLOCK: u64 = 25_346_377;
+pub const HYPERMAP_FIRST_BLOCK: u64 = 27_270_411;
 /// the root hash of hypermap, empty bytes32
 pub const HYPERMAP_ROOT_HASH: &'static str =
     "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,12 @@ pub mod homepage;
 /// Your process must have the [`Capability`] to message and receive messages from
 /// `http-server:distro:sys` and/or `http-client:distro:sys` to use this module.
 pub mod http;
+/// Interact with hypermap, the onchain namespace
+pub mod hypermap;
 /// The types that the kernel itself uses -- warning -- these will
 /// be incompatible with WIT types in some cases, leading to annoying errors.
 /// Use only to interact with the kernel or runtime in certain ways.
 pub mod kernel_types;
-/// Interact with hypermap, the onchain namespace
-pub mod hypermap;
 /// Interact with the key_value module
 ///
 /// Your process must have the [`Capability`] to message and receive messages from


### PR DESCRIPTION
## Problem

First block was for old deployment

## Solution

Update to new deployment, see https://basescan.org/tx/0xc2008d8e5bbd117410ca16c739acbd42e420ec9c52488e916af7a235dc6fb4c8

## Docs Update

None

## Notes

None