### PR TITLE
add (de)serialization methods for blob & SendError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "alloy-sol-macro",
  "alloy-sol-types",
  "anyhow",
+ "base64",
  "bincode",
  "color-eyre",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ alloy = { version = "0.8.1", features = [
     "rpc-types",
 ] }
 anyhow = "1.0"
+base64 = "0.22.1"
 bincode = "1.3.3"
 color-eyre = { version = "0.6", features = ["capture-spantrace"], optional = true }
 http = "1.0.0"

--- a/src/types/lazy_load_blob.rs
+++ b/src/types/lazy_load_blob.rs
@@ -1,3 +1,10 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 pub use crate::LazyLoadBlob;
 
 /// `LazyLoadBlob` is defined in the wit bindings, but constructors and methods here.
@@ -40,5 +47,96 @@ impl std::default::Default for LazyLoadBlob {
 impl std::cmp::PartialEq for LazyLoadBlob {
     fn eq(&self, other: &Self) -> bool {
         self.mime == other.mime && self.bytes == other.bytes
+    }
+}
+
+impl Serialize for LazyLoadBlob {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Create a struct with 2 fields
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("LazyLoadBlob", 2)?;
+
+        // Serialize mime normally (serde handles Option automatically)
+        state.serialize_field("mime", &self.mime)?;
+
+        let base64_data = BASE64.encode(&self.bytes);
+        state.serialize_field("bytes", &base64_data)?;
+
+        state.end()
+    }
+}
+
+// Custom visitor for deserialization
+struct LazyLoadBlobVisitor {
+    marker: PhantomData<fn() -> LazyLoadBlob>,
+}
+
+impl LazyLoadBlobVisitor {
+    fn new() -> Self {
+        LazyLoadBlobVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for LazyLoadBlobVisitor {
+    type Value = LazyLoadBlob;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a struct with mime and bytes fields")
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: de::MapAccess<'de>,
+    {
+        let mut mime = None;
+        let mut bytes_base64 = None;
+
+        // Extract each field from the map
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "mime" => {
+                    if mime.is_some() {
+                        return Err(de::Error::duplicate_field("mime"));
+                    }
+                    mime = map.next_value()?;
+                }
+                "bytes" => {
+                    if bytes_base64.is_some() {
+                        return Err(de::Error::duplicate_field("bytes"));
+                    }
+                    bytes_base64 = Some(map.next_value::<String>()?);
+                }
+                _ => {
+                    // Skip unknown fields
+                    let _ = map.next_value::<de::IgnoredAny>()?;
+                }
+            }
+        }
+
+        let bytes_base64 = bytes_base64.ok_or_else(|| de::Error::missing_field("bytes"))?;
+
+        let bytes = BASE64
+            .decode(bytes_base64.as_bytes())
+            .map_err(|err| de::Error::custom(format!("Invalid base64: {}", err)))?;
+
+        Ok(LazyLoadBlob { mime, bytes })
+    }
+}
+
+impl<'de> Deserialize<'de> for LazyLoadBlob {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_struct(
+            "LazyLoadBlob",
+            &["mime", "bytes"],
+            LazyLoadBlobVisitor::new(),
+        )
     }
 }

--- a/src/types/send_error.rs
+++ b/src/types/send_error.rs
@@ -1,7 +1,7 @@
 use crate::{Address, LazyLoadBlob, Message, _wit_message_to_message};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SendError {
     pub kind: SendErrorKind,
     pub target: Address,


### PR DESCRIPTION
## Problem

App Framework needs to (de)serialize SendError, and hence, LazyLoadBlob.

## Solution

Add base64-based (de)seralization to work nicely with JSON.

## Docs Update

None

## Notes

None