### PR TITLE
logging: change remote log serialization format to string for more efficient sending

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -42,7 +42,7 @@ pub struct TerminalWriterMaker {
 
 impl std::io::Write for RemoteWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let log = if let Ok(json_log) = serde_json::from_slice(buf) {
+        let log = if let Ok(json_log) = serde_json::from_slice::<serde_json::Value>(buf) {
             serde_json::to_string(&json_log).unwrap()
         } else {
             let string = String::from_utf8(buf.to_vec())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -42,7 +42,14 @@ pub struct TerminalWriterMaker {
 
 impl std::io::Write for RemoteWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let body = serde_json::json!({"Log": buf});
+        let log = if let Ok(json_log) = serde_json::from_slice(buf) {
+            serde_json::to_string(&json_log).unwrap()
+        } else {
+            let string = String::from_utf8(buf.to_vec())
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            string
+        };
+        let body = serde_json::json!({"Log": log});
         let body = serde_json::to_vec(&body).unwrap();
         Request::to(&self.target).body(body).send().unwrap();
         Ok(buf.len())

--- a/src/vfs/file.rs
+++ b/src/vfs/file.rs
@@ -6,6 +6,7 @@ use crate::{get_blob, PackageId};
 /// VFS (Virtual File System) helper struct for a file.
 /// Opening or creating a `File` will give you a `Result<File, VfsError>`.
 /// You can call its impl functions to interact with it.
+#[derive(serde::Deserialize, serde::Serialize)]
 pub struct File {
     pub path: String,
     pub timeout: u64,


### PR DESCRIPTION
## Problem

Remote logging serializes logs to Vec<u8> which is very efficient for JSON (it becomes an array of numbers).

## Solution

Serialize logs to String instead for more efficient sending.

## Docs Update

[TODO](https://github.com/hyperware-ai/hyperware-book/issues/280)

## Notes

None